### PR TITLE
Sampling from demo models with original @submodel definition

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using Test
 
 Random.seed!(100)
 
+# no-op
+
 @testset verbose = true "DynamicPPL.jl" begin
     @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
         N = 1000


### PR DESCRIPTION
Prior to this PR, the entire testset has been deleted and replaced with a call to `sample(model, SampleFromUniform(), 1000) for model in DynamicPPL.TestUtils.DEMO_MODELS`: see https://github.com/penelopeysm/DynamicPPL.jl/blob/master/test/runtests.jl

This mimics the `init` testset in the original `test/sampler.jl`: see https://github.com/TuringLang/DynamicPPL.jl/blob/5c8fc59c9c5650c8f522dddad9ac1800834c6851/test/sampler.jl#L35

This PR times how long it takes to sample each demo model in DynamicPPL.

## Local timings (macOS, Julia 1.11, aarch64, 1 thread)

```
Test Summary:                                | Total   Time
DynamicPPL.jl                                |     0  16.0s
  demo_dot_assume_dot_observe                |     0   2.6s
  demo_assume_index_observe                  |     0   0.4s
  demo_assume_multivariate_observe           |     0   1.3s
  demo_dot_assume_observe_index              |     0   0.6s
  demo_assume_dot_observe                    |     0   0.7s
  demo_assume_multivariate_observe_literal   |     0   0.4s
  demo_dot_assume_observe_index_literal      |     0   0.6s
  demo_assume_dot_observe_literal            |     0   0.3s
  demo_assume_observe_literal                |     0   0.4s
  demo_assume_submodel_observe_index_literal |     0   3.4s
  demo_dot_assume_observe_submodel           |     0   2.7s
  demo_dot_assume_dot_observe_matrix         |     0   0.6s
  demo_dot_assume_matrix_dot_observe_matrix  |     0   1.5s
  demo_assume_matrix_dot_observe_matrix      |     0   0.6s
     Testing DynamicPPL tests passed
```

## CI (ubuntu-latest, Julia 1.11, x64, 2 threads)

```
Test Summary:                                | Total     Time    Ratio vs local
DynamicPPL.jl                                |     0  2m15.5s     8.47x
  demo_dot_assume_dot_observe                |     0     5.1s     1.96x
  demo_assume_index_observe                  |     0     1.1s     2.75x
  demo_assume_multivariate_observe           |     0     2.6s     2.00x
  demo_dot_assume_observe_index              |     0     1.3s     2.17x
  demo_assume_dot_observe                    |     0     1.5s     2.14x
  demo_assume_multivariate_observe_literal   |     0     0.8s     2.00x
  demo_dot_assume_observe_index_literal      |     0     1.2s     2.00x
  demo_assume_dot_observe_literal            |     0     0.7s     2.33x
  demo_assume_observe_literal                |     0     0.7s     1.75x
  demo_assume_submodel_observe_index_literal |     0    58.1s    17.09x
  demo_dot_assume_observe_submodel           |     0    56.7s    21.00x
  demo_dot_assume_dot_observe_matrix         |     0     1.4s     2.33x
  demo_dot_assume_matrix_dot_observe_matrix  |     0     3.0s     2.00x
  demo_assume_matrix_dot_observe_matrix      |     0     1.2s     2.00x
     Testing DynamicPPL tests passed 
```

## CI (macOS, Julia 1.11, aarch64, 2 threads)

```
Test Summary:                                | Total   Time    Ratio v local
DynamicPPL.jl                                |     0  17.8s     1.11x
  demo_dot_assume_dot_observe                |     0   3.2s     1.23x
  demo_assume_index_observe                  |     0   0.6s     1.50x
  demo_assume_multivariate_observe           |     0   1.4s     1.08x
  demo_dot_assume_observe_index              |     0   0.7s     1.17x
  demo_assume_dot_observe                    |     0   0.8s     1.14x
  demo_assume_multivariate_observe_literal   |     0   0.4s     1.00x
  demo_dot_assume_observe_index_literal      |     0   0.6s     1.00x
  demo_assume_dot_observe_literal            |     0   0.4s     1.33x
  demo_assume_observe_literal                |     0   0.4s     1.00x
  demo_assume_submodel_observe_index_literal |     0   3.6s     1.06x
  demo_dot_assume_observe_submodel           |     0   2.7s     1.00x
  demo_dot_assume_dot_observe_matrix         |     0   0.7s     1.17x
  demo_dot_assume_matrix_dot_observe_matrix  |     0   1.6s     1.07x
  demo_assume_matrix_dot_observe_matrix      |     0   0.7s     1.17x
     Testing DynamicPPL tests passed 
```