### PR TITLE
Sampling from demo_models with `to_submodel()`

### DIFF
--- a/src/test_utils/models.jl
+++ b/src/test_utils/models.jl
@@ -437,7 +437,8 @@ end
 
 @model function demo_assume_submodel_observe_index_literal()
     # Submodel prior
-    @submodel s, m = _prior_dot_assume()
+    priors ~ to_submodel(_prior_dot_assume())
+    s, m = priors
     1.5 ~ Normal(m[1], sqrt(s[1]))
     2.0 ~ Normal(m[2], sqrt(s[2]))
 
@@ -475,7 +476,7 @@ end
     m .~ Normal.(0, sqrt.(s))
 
     # Submodel likelihood
-    @submodel _likelihood_mltivariate_observe(s, m, x)
+    _ignore ~ to_submodel(_likelihood_mltivariate_observe(s, m, x))
 
     return (; s=s, m=m, x=x, logp=getlogp(__varinfo__))
 end


### PR DESCRIPTION
This PR is the same as #2 except that the demo models with `@submodel` have been updated to use `to_submodel()`.

Note that making this change in DynamicPPL proper will cause larger breakage due to varname prefixing.

This PR times how long it takes to sample each demo model.

## Local timings (macOS, Julia 1.11, aarch64, 1 thread)

```
Test Summary:                                | Total   Time
DynamicPPL.jl                                |     0  11.8s
  demo_dot_assume_dot_observe                |     0   2.4s
  demo_assume_index_observe                  |     0   0.4s
  demo_assume_multivariate_observe           |     0   1.1s
  demo_dot_assume_observe_index              |     0   0.5s
  demo_assume_dot_observe                    |     0   0.6s
  demo_assume_multivariate_observe_literal   |     0   0.3s
  demo_dot_assume_observe_index_literal      |     0   0.5s
  demo_assume_dot_observe_literal            |     0   0.3s
  demo_assume_observe_literal                |     0   0.3s
  demo_assume_submodel_observe_index_literal |     0   1.8s
  demo_dot_assume_observe_submodel           |     0   0.6s
  demo_dot_assume_dot_observe_matrix         |     0   0.7s
  demo_dot_assume_matrix_dot_observe_matrix  |     0   1.6s
  demo_assume_matrix_dot_observe_matrix      |     0   0.6s
     Testing DynamicPPL tests passed
```

## CI (ubuntu-latest, Julia 1.11, x64, 2 threads)

```
Test Summary:                                | Total   Time
DynamicPPL.jl                                |     0  25.4s
  demo_dot_assume_dot_observe                |     0   4.9s
  demo_assume_index_observe                  |     0   1.0s
  demo_assume_multivariate_observe           |     0   2.4s
  demo_dot_assume_observe_index              |     0   1.2s
  demo_assume_dot_observe                    |     0   1.4s
  demo_assume_multivariate_observe_literal   |     0   0.7s
  demo_dot_assume_observe_index_literal      |     0   1.2s
  demo_assume_dot_observe_literal            |     0   0.7s
  demo_assume_observe_literal                |     0   0.7s
  demo_assume_submodel_observe_index_literal |     0   4.0s
  demo_dot_assume_observe_submodel           |     0   1.4s
  demo_dot_assume_dot_observe_matrix         |     0   1.4s
  demo_dot_assume_matrix_dot_observe_matrix  |     0   3.0s
  demo_assume_matrix_dot_observe_matrix      |     0   1.2s
     Testing DynamicPPL tests passed 
```

## CI (macOS, Julia 1.11, aarch64, 2 threads)

```
Test Summary:                                | Total   Time
DynamicPPL.jl                                |     0  12.8s
  demo_dot_assume_dot_observe                |     0   2.5s
  demo_assume_index_observe                  |     0   0.5s
  demo_assume_multivariate_observe           |     0   1.2s
  demo_dot_assume_observe_index              |     0   0.6s
  demo_assume_dot_observe                    |     0   0.7s
  demo_assume_multivariate_observe_literal   |     0   0.4s
  demo_dot_assume_observe_index_literal      |     0   0.6s
  demo_assume_dot_observe_literal            |     0   0.4s
  demo_assume_observe_literal                |     0   0.4s
  demo_assume_submodel_observe_index_literal |     0   2.0s
  demo_dot_assume_observe_submodel           |     0   0.7s
  demo_dot_assume_dot_observe_matrix         |     0   0.7s
  demo_dot_assume_matrix_dot_observe_matrix  |     0   1.5s
  demo_assume_matrix_dot_observe_matrix      |     0   0.6s
     Testing DynamicPPL tests passed 
```